### PR TITLE
Made parameters of generic vector functions const where applicable.

### DIFF
--- a/linmath.h
+++ b/linmath.h
@@ -5,25 +5,25 @@
 
 #define LINMATH_H_DEFINE_VEC(n) \
 typedef float vec##n[n]; \
-static inline void vec##n##_add(vec##n r, vec##n a, vec##n b) \
+static inline void vec##n##_add(vec##n r, vec##n const a, vec##n const b) \
 { \
 	int i; \
 	for(i=0; i<n; ++i) \
 		r[i] = a[i] + b[i]; \
 } \
-static inline void vec##n##_sub(vec##n r, vec##n a, vec##n b) \
+static inline void vec##n##_sub(vec##n r, vec##n const a, vec##n const b) \
 { \
 	int i; \
 	for(i=0; i<n; ++i) \
 		r[i] = a[i] - b[i]; \
 } \
-static inline void vec##n##_scale(vec##n r, vec##n v, float s) \
+static inline void vec##n##_scale(vec##n r, vec##n const v, float const s) \
 { \
 	int i; \
 	for(i=0; i<n; ++i) \
 		r[i] = v[i] * s; \
 } \
-static inline float vec##n##_mul_inner(vec##n a, vec##n b) \
+static inline float vec##n##_mul_inner(vec##n const a, vec##n const b) \
 { \
 	float p = 0.; \
 	int i; \
@@ -31,11 +31,11 @@ static inline float vec##n##_mul_inner(vec##n a, vec##n b) \
 		p += b[i]*a[i]; \
 	return p; \
 } \
-static inline float vec##n##_len(vec##n v) \
+static inline float vec##n##_len(vec##n const v) \
 { \
 	return sqrtf(vec##n##_mul_inner(v,v)); \
 } \
-static inline void vec##n##_norm(vec##n r, vec##n v) \
+static inline void vec##n##_norm(vec##n r, vec##n const v) \
 { \
 	float k = 1.0 / vec##n##_len(v); \
 	vec##n##_scale(r, v, k); \


### PR DESCRIPTION
This fixed all warnings that gcc with -Wall gave me.

Thanks for creating this library by the way :D