### PR TITLE
Fix bug in quat_mul_vec3 caused by reuse of u and t in 'vec3_mul_cross'

### DIFF
--- a/linmath.h
+++ b/linmath.h
@@ -481,13 +481,14 @@ static inline void quat_mul_vec3(vec3 r, quat q, vec3 v)
 t = 2 * cross(q.xyz, v)
 v' = v + q.w * t + cross(q.xyz, t)
  */
-	vec3 t = {q[0], q[1], q[2]};
+	vec3 t;
+	vec3 q_xyz = {q[0], q[1], q[2]};
 	vec3 u = {q[0], q[1], q[2]};
 
-	vec3_mul_cross(t, t, v);
+	vec3_mul_cross(t, q_xyz, v);
 	vec3_scale(t, t, 2);
 
-	vec3_mul_cross(u, u, t);
+	vec3_mul_cross(u, q_xyz, t);
 	vec3_scale(t, t, q[3]);
 
 	vec3_add(r, v, t);


### PR DESCRIPTION
The new implementation of `quat_mul_vec3` introduced in commit 06b68f6caa214d9f98ada28db837c21e08ed2927 incorrectly calculates 't' and 'u'. The problem's caused by the variables being used as both input and output to `vec3_mul_cross`, which causes the variables to be corrupted as the cross product is taken. Unlike with the simple vector operations, input variables to vec3_mul_cross must be distinct from the output variable.

```
static inline void vec3_mul_cross(vec3 r, vec3 const a, vec3 const b) {
    r[0] = a[1]*b[2] - a[2]*b[1];
    r[1] = a[2]*b[0] - a[0]*b[2];
    r[2] = a[0]*b[1] - a[1]*b[0];
}
```