### PR TITLE
#include <string.h> to avoid implicit declaration of memcpy

### DIFF
--- a/linmath.h
+++ b/linmath.h
@@ -2,6 +2,7 @@
 #define LINMATH_H
 
 #include <math.h>
+#include <string.h>
 
 #ifdef LINMATH_NO_INLINE
 #define LINMATH_H_FUNC static


### PR DESCRIPTION
I just added `#include <string.h>` at the top of the file to fix some compiler warnings of implicit declaration of `memcpy`.