### PR TITLE
Fixed an MSVC Compiler Error.

### DIFF
--- a/linmath.h
+++ b/linmath.h
@@ -3,6 +3,12 @@
 
 #include <math.h>
 
+/*To bypass the MSVC Compiler Error C3861
+'memcpy': identifier not found*/
+#if (defined(_WIN32) || defined(_WIN64))
+void* memcpy(void* dest, const void* src, size_t count);
+#endif
+
 #ifdef LINMATH_NO_INLINE
 #define LINMATH_H_FUNC static
 #else


### PR DESCRIPTION
Upon using this header in Visual Studio projects. The MSVC reports Compiler Error C3861.

![C3861](https://user-images.githubusercontent.com/8848319/86945189-61366080-c166-11ea-9d7b-f5e2313222fd.JPG)

Therefore, added a preprocessor directive to check if this header is being compiled with MSVC, if so, then include a prototype for `memcpy` function to fix this.

