### PR TITLE
Added tests, fixed a bug, and more

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+jobs:
+  linmath-test:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+     - run: gcc --version
+     - checkout
+     - run:
+         command: |
+           gcc -O0 -o linmath_test.o linmath_test.c -lm
+           ./linmath_test.o
+         name: linmath tests gcc -O0
+     - run:
+         command: |
+           gcc -O1 -o linmath_test.o linmath_test.c -lm
+           ./linmath_test.o
+         name: linmath tests gcc -O1
+     - run:
+         command: |
+           gcc -O2 -o linmath_test.o linmath_test.c -lm
+           ./linmath_test.o
+         name: linmath tests gcc -O2
+     - run:
+         command: |
+           gcc -O3 -o linmath_test.o linmath_test.c -lm
+           ./linmath_test.o
+         name: linmath tests gcc -O3
+
+
+workflows:
+  main:
+    jobs:
+      - linmath-test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # linmath.h -- A small library for linear math as required for computer graphics
 
+[![CircleCI](https://circleci.com/gh/datenwolf/linmath.h.svg?style=svg)](https://app.circleci.com/pipelines/github/datenwolf/linmath.h)
+
+
 linmath.h provides the most used types required for programming computer graphics:
 
 vec3 -- 3 element vector of floats

--- a/linmath.h
+++ b/linmath.h
@@ -1,6 +1,7 @@
 #ifndef LINMATH_H
 #define LINMATH_H
 
+#include <string.h>
 #include <math.h>
 
 #ifdef LINMATH_NO_INLINE
@@ -31,7 +32,7 @@ LINMATH_H_FUNC void vec##n##_scale(vec##n r, vec##n const v, float const s) \
 } \
 LINMATH_H_FUNC float vec##n##_mul_inner(vec##n const a, vec##n const b) \
 { \
-	float p = 0.; \
+	float p = 0.f; \
 	int i; \
 	for(i=0; i<n; ++i) \
 		p += b[i]*a[i]; \
@@ -43,7 +44,7 @@ LINMATH_H_FUNC float vec##n##_len(vec##n const v) \
 } \
 LINMATH_H_FUNC void vec##n##_norm(vec##n r, vec##n const v) \
 { \
-	float k = 1.0 / vec##n##_len(v); \
+	float k = 1.f / vec##n##_len(v); \
 	vec##n##_scale(r, v, k); \
 } \
 LINMATH_H_FUNC void vec##n##_min(vec##n r, vec##n const a, vec##n const b) \
@@ -57,6 +58,12 @@ LINMATH_H_FUNC void vec##n##_max(vec##n r, vec##n const a, vec##n const b) \
 	int i; \
 	for(i=0; i<n; ++i) \
 		r[i] = a[i]>b[i] ? a[i] : b[i]; \
+} \
+LINMATH_H_FUNC void vec##n##_dup(vec##n r, vec##n const src) \
+{ \
+	int i; \
+	for(i=0; i<n; ++i) \
+		r[i] = src[i]; \
 }
 
 LINMATH_H_DEFINE_VEC(2)
@@ -78,7 +85,7 @@ LINMATH_H_FUNC void vec3_reflect(vec3 r, vec3 const v, vec3 const n)
 		r[i] = v[i] - p*n[i];
 }
 
-LINMATH_H_FUNC void vec4_mul_cross(vec4 r, vec4 a, vec4 b)
+LINMATH_H_FUNC void vec4_mul_cross(vec4 r, vec4 const a, vec4 const b)
 {
 	r[0] = a[1]*b[2] - a[2]*b[1];
 	r[1] = a[2]*b[0] - a[0]*b[2];
@@ -86,7 +93,7 @@ LINMATH_H_FUNC void vec4_mul_cross(vec4 r, vec4 a, vec4 b)
 	r[3] = 1.f;
 }
 
-LINMATH_H_FUNC void vec4_reflect(vec4 r, vec4 v, vec4 n)
+LINMATH_H_FUNC void vec4_reflect(vec4 r, vec4 const v, vec4 const n)
 {
 	float p  = 2.f*vec4_mul_inner(v, n);
 	int i;
@@ -102,61 +109,59 @@ LINMATH_H_FUNC void mat4x4_identity(mat4x4 M)
 		for(j=0; j<4; ++j)
 			M[i][j] = i==j ? 1.f : 0.f;
 }
-LINMATH_H_FUNC void mat4x4_dup(mat4x4 M, mat4x4 N)
+LINMATH_H_FUNC void mat4x4_dup(mat4x4 M, mat4x4 const N)
 {
-	int i, j;
+	int i;
 	for(i=0; i<4; ++i)
-		for(j=0; j<4; ++j)
-			M[i][j] = N[i][j];
+		vec4_dup(M[i], N[i]);
 }
-LINMATH_H_FUNC void mat4x4_row(vec4 r, mat4x4 M, int i)
+LINMATH_H_FUNC void mat4x4_row(vec4 r, mat4x4 const M, int i)
 {
 	int k;
 	for(k=0; k<4; ++k)
 		r[k] = M[k][i];
 }
-LINMATH_H_FUNC void mat4x4_col(vec4 r, mat4x4 M, int i)
+LINMATH_H_FUNC void mat4x4_col(vec4 r, mat4x4 const M, int i)
 {
 	int k;
 	for(k=0; k<4; ++k)
 		r[k] = M[i][k];
 }
-LINMATH_H_FUNC void mat4x4_transpose(mat4x4 M, mat4x4 N)
+LINMATH_H_FUNC void mat4x4_transpose(mat4x4 M, mat4x4 const N)
 {
+    // Note: if M and N are the same, the user has to
+    // explicitly make a copy of M and set it to N.
 	int i, j;
 	for(j=0; j<4; ++j)
 		for(i=0; i<4; ++i)
 			M[i][j] = N[j][i];
 }
-LINMATH_H_FUNC void mat4x4_add(mat4x4 M, mat4x4 a, mat4x4 b)
+LINMATH_H_FUNC void mat4x4_add(mat4x4 M, mat4x4 const a, mat4x4 const b)
 {
 	int i;
 	for(i=0; i<4; ++i)
 		vec4_add(M[i], a[i], b[i]);
 }
-LINMATH_H_FUNC void mat4x4_sub(mat4x4 M, mat4x4 a, mat4x4 b)
+LINMATH_H_FUNC void mat4x4_sub(mat4x4 M, mat4x4 const a, mat4x4 const b)
 {
 	int i;
 	for(i=0; i<4; ++i)
 		vec4_sub(M[i], a[i], b[i]);
 }
-LINMATH_H_FUNC void mat4x4_scale(mat4x4 M, mat4x4 a, float k)
+LINMATH_H_FUNC void mat4x4_scale(mat4x4 M, mat4x4 const a, float k)
 {
 	int i;
 	for(i=0; i<4; ++i)
 		vec4_scale(M[i], a[i], k);
 }
-LINMATH_H_FUNC void mat4x4_scale_aniso(mat4x4 M, mat4x4 a, float x, float y, float z)
+LINMATH_H_FUNC void mat4x4_scale_aniso(mat4x4 M, mat4x4 const a, float x, float y, float z)
 {
-	int i;
 	vec4_scale(M[0], a[0], x);
 	vec4_scale(M[1], a[1], y);
 	vec4_scale(M[2], a[2], z);
-	for(i = 0; i < 4; ++i) {
-		M[3][i] = a[3][i];
-	}
+	vec4_dup(M[3], a[3]);
 }
-LINMATH_H_FUNC void mat4x4_mul(mat4x4 M, mat4x4 a, mat4x4 b)
+LINMATH_H_FUNC void mat4x4_mul(mat4x4 M, mat4x4 const a, mat4x4 const b)
 {
 	mat4x4 temp;
 	int k, r, c;
@@ -167,7 +172,7 @@ LINMATH_H_FUNC void mat4x4_mul(mat4x4 M, mat4x4 a, mat4x4 b)
 	}
 	mat4x4_dup(M, temp);
 }
-LINMATH_H_FUNC void mat4x4_mul_vec4(vec4 r, mat4x4 M, vec4 v)
+LINMATH_H_FUNC void mat4x4_mul_vec4(vec4 r, mat4x4 const M, vec4 const v)
 {
 	int i, j;
 	for(j=0; j<4; ++j) {
@@ -193,13 +198,13 @@ LINMATH_H_FUNC void mat4x4_translate_in_place(mat4x4 M, float x, float y, float 
 		M[3][i] += vec4_mul_inner(r, t);
 	}
 }
-LINMATH_H_FUNC void mat4x4_from_vec3_mul_outer(mat4x4 M, vec3 a, vec3 b)
+LINMATH_H_FUNC void mat4x4_from_vec3_mul_outer(mat4x4 M, vec3 const a, vec3 const b)
 {
 	int i, j;
 	for(i=0; i<4; ++i) for(j=0; j<4; ++j)
 		M[i][j] = i<3 && j<3 ? a[i] * b[j] : 0.f;
 }
-LINMATH_H_FUNC void mat4x4_rotate(mat4x4 R, mat4x4 M, float x, float y, float z, float angle)
+LINMATH_H_FUNC void mat4x4_rotate(mat4x4 R, mat4x4 const M, float x, float y, float z, float angle)
 {
 	float s = sinf(angle);
 	float c = cosf(angle);
@@ -227,13 +232,13 @@ LINMATH_H_FUNC void mat4x4_rotate(mat4x4 R, mat4x4 M, float x, float y, float z,
 		mat4x4_add(T, T, C);
 		mat4x4_add(T, T, S);
 
-		T[3][3] = 1.;		
+		T[3][3] = 1.f;
 		mat4x4_mul(R, M, T);
 	} else {
 		mat4x4_dup(R, M);
 	}
 }
-LINMATH_H_FUNC void mat4x4_rotate_X(mat4x4 Q, mat4x4 M, float angle)
+LINMATH_H_FUNC void mat4x4_rotate_X(mat4x4 Q, mat4x4 const M, float angle)
 {
 	float s = sinf(angle);
 	float c = cosf(angle);
@@ -245,7 +250,7 @@ LINMATH_H_FUNC void mat4x4_rotate_X(mat4x4 Q, mat4x4 M, float angle)
 	};
 	mat4x4_mul(Q, M, R);
 }
-LINMATH_H_FUNC void mat4x4_rotate_Y(mat4x4 Q, mat4x4 M, float angle)
+LINMATH_H_FUNC void mat4x4_rotate_Y(mat4x4 Q, mat4x4 const M, float angle)
 {
 	float s = sinf(angle);
 	float c = cosf(angle);
@@ -257,7 +262,7 @@ LINMATH_H_FUNC void mat4x4_rotate_Y(mat4x4 Q, mat4x4 M, float angle)
 	};
 	mat4x4_mul(Q, M, R);
 }
-LINMATH_H_FUNC void mat4x4_rotate_Z(mat4x4 Q, mat4x4 M, float angle)
+LINMATH_H_FUNC void mat4x4_rotate_Z(mat4x4 Q, mat4x4 const M, float angle)
 {
 	float s = sinf(angle);
 	float c = cosf(angle);
@@ -269,7 +274,7 @@ LINMATH_H_FUNC void mat4x4_rotate_Z(mat4x4 Q, mat4x4 M, float angle)
 	};
 	mat4x4_mul(Q, M, R);
 }
-LINMATH_H_FUNC void mat4x4_invert(mat4x4 T, mat4x4 M)
+LINMATH_H_FUNC void mat4x4_invert(mat4x4 T, mat4x4 const M)
 {
 	float s[6];
 	float c[6];
@@ -310,10 +315,10 @@ LINMATH_H_FUNC void mat4x4_invert(mat4x4 T, mat4x4 M)
 	T[3][2] = (-M[3][0] * s[3] + M[3][1] * s[1] - M[3][2] * s[0]) * idet;
 	T[3][3] = ( M[2][0] * s[3] - M[2][1] * s[1] + M[2][2] * s[0]) * idet;
 }
-LINMATH_H_FUNC void mat4x4_orthonormalize(mat4x4 R, mat4x4 M)
+LINMATH_H_FUNC void mat4x4_orthonormalize(mat4x4 R, mat4x4 const M)
 {
 	mat4x4_dup(R, M);
-	float s = 1.;
+	float s = 1.f;
 	vec3 h;
 
 	vec3_norm(R[2], R[2]);
@@ -338,7 +343,7 @@ LINMATH_H_FUNC void mat4x4_frustum(mat4x4 M, float l, float r, float b, float t,
 	M[0][0] = 2.f*n/(r-l);
 	M[0][1] = M[0][2] = M[0][3] = 0.f;
 	
-	M[1][1] = 2.*n/(t-b);
+	M[1][1] = 2.f*n/(t-b);
 	M[1][0] = M[1][2] = M[1][3] = 0.f;
 
 	M[2][0] = (r+l)/(r-l);
@@ -369,7 +374,7 @@ LINMATH_H_FUNC void mat4x4_perspective(mat4x4 m, float y_fov, float aspect, floa
 {
 	/* NOTE: Degrees are an unhandy unit to work with.
 	 * linmath.h uses radians for everything! */
-	float const a = 1.f / tan(y_fov / 2.f);
+	float const a = 1.f / tanf(y_fov / 2.f);
 
 	m[0][0] = a / aspect;
 	m[0][1] = 0.f;
@@ -391,7 +396,7 @@ LINMATH_H_FUNC void mat4x4_perspective(mat4x4 m, float y_fov, float aspect, floa
 	m[3][2] = -((2.f * f * n) / (f - n));
 	m[3][3] = 0.f;
 }
-LINMATH_H_FUNC void mat4x4_look_at(mat4x4 m, vec3 eye, vec3 center, vec3 up)
+LINMATH_H_FUNC void mat4x4_look_at(mat4x4 m, vec3 const eye, vec3 const center, vec3 const up)
 {
 	/* Adapted from Android's OpenGL Matrix.java.                        */
 	/* See the OpenGL GLUT documentation for gluLookAt for a description */
@@ -434,24 +439,18 @@ LINMATH_H_FUNC void mat4x4_look_at(mat4x4 m, vec3 eye, vec3 center, vec3 up)
 }
 
 typedef float quat[4];
+#define quat_add vec4_add
+#define quat_sub vec4_sub
+#define quat_norm vec4_norm
+#define quat_scale vec4_scale
+#define quat_mul_inner vec4_mul_inner
+
 LINMATH_H_FUNC void quat_identity(quat q)
 {
 	q[0] = q[1] = q[2] = 0.f;
 	q[3] = 1.f;
 }
-LINMATH_H_FUNC void quat_add(quat r, quat a, quat b)
-{
-	int i;
-	for(i=0; i<4; ++i)
-		r[i] = a[i] + b[i];
-}
-LINMATH_H_FUNC void quat_sub(quat r, quat a, quat b)
-{
-	int i;
-	for(i=0; i<4; ++i)
-		r[i] = a[i] - b[i];
-}
-LINMATH_H_FUNC void quat_mul(quat r, quat p, quat q)
+LINMATH_H_FUNC void quat_mul(quat r, quat const p, quat const q)
 {
 	vec3 w;
 	vec3_mul_cross(r, p, q);
@@ -461,37 +460,22 @@ LINMATH_H_FUNC void quat_mul(quat r, quat p, quat q)
 	vec3_add(r, r, w);
 	r[3] = p[3]*q[3] - vec3_mul_inner(p, q);
 }
-LINMATH_H_FUNC void quat_scale(quat r, quat v, float s)
-{
-	int i;
-	for(i=0; i<4; ++i)
-		r[i] = v[i] * s;
-}
-LINMATH_H_FUNC float quat_inner_product(quat a, quat b)
-{
-	float p = 0.f;
-	int i;
-	for(i=0; i<4; ++i)
-		p += b[i]*a[i];
-	return p;
-}
-LINMATH_H_FUNC void quat_conj(quat r, quat q)
+LINMATH_H_FUNC void quat_conj(quat r, quat const q)
 {
 	int i;
 	for(i=0; i<3; ++i)
 		r[i] = -q[i];
 	r[3] = q[3];
 }
-LINMATH_H_FUNC void quat_rotate(quat r, float angle, vec3 axis) {
-	vec3 v;
-	vec3_scale(v, axis, sinf(angle / 2));
-	int i;
-	for(i=0; i<3; ++i)
-		r[i] = v[i];
-	r[3] = cosf(angle / 2);
+LINMATH_H_FUNC void quat_rotate(quat r, float angle, vec3 const axis) {
+    vec3 axis_norm;
+    vec3_norm(axis_norm, axis);
+    float s = sinf(angle / 2);
+    float c = cosf(angle / 2);
+    vec3_scale(r, axis_norm, s);
+    r[3] = c;
 }
-#define quat_norm vec4_norm
-LINMATH_H_FUNC void quat_mul_vec3(vec3 r, quat q, vec3 v)
+LINMATH_H_FUNC void quat_mul_vec3(vec3 r, quat const q, vec3 const v)
 {
 /*
  * Method by Fabian 'ryg' Giessen (of Farbrausch)
@@ -511,7 +495,7 @@ v' = v + q.w * t + cross(q.xyz, t)
 	vec3_add(r, v, t);
 	vec3_add(r, r, u);
 }
-LINMATH_H_FUNC void mat4x4_from_quat(mat4x4 M, quat q)
+LINMATH_H_FUNC void mat4x4_from_quat(mat4x4 M, quat const q)
 {
 	float a = q[3];
 	float b = q[0];
@@ -541,18 +525,21 @@ LINMATH_H_FUNC void mat4x4_from_quat(mat4x4 M, quat q)
 	M[3][3] = 1.f;
 }
 
-LINMATH_H_FUNC void mat4x4o_mul_quat(mat4x4 R, mat4x4 M, quat q)
+LINMATH_H_FUNC void mat4x4o_mul_quat(mat4x4 R, mat4x4 const M, quat const q)
 {
-/*  XXX: The way this is written only works for othogonal matrices. */
+/*  XXX: The way this is written only works for orthogonal matrices. */
 /* TODO: Take care of non-orthogonal case. */
 	quat_mul_vec3(R[0], q, M[0]);
 	quat_mul_vec3(R[1], q, M[1]);
 	quat_mul_vec3(R[2], q, M[2]);
 
 	R[3][0] = R[3][1] = R[3][2] = 0.f;
-	R[3][3] = 1.f;
+	R[0][3] = M[0][3];
+	R[1][3] = M[1][3];
+	R[2][3] = M[2][3];
+	R[3][3] = M[3][3];  // typically 1.0, but here we make it general
 }
-LINMATH_H_FUNC void quat_from_mat4x4(quat q, mat4x4 M)
+LINMATH_H_FUNC void quat_from_mat4x4(quat q, mat4x4 const M)
 {
 	float r=0.f;
 	int i;
@@ -582,7 +569,7 @@ LINMATH_H_FUNC void quat_from_mat4x4(quat q, mat4x4 M)
 	q[3] = (M[p[2]][p[1]] - M[p[1]][p[2]])/(2.f*r);
 }
 
-LINMATH_H_FUNC void mat4x4_arcball(mat4x4 R, mat4x4 M, vec2 _a, vec2 _b, float s)
+LINMATH_H_FUNC void mat4x4_arcball(mat4x4 R, mat4x4 const M, vec2 const _a, vec2 const _b, float s)
 {
 	vec2 a; memcpy(a, _a, sizeof(a));
 	vec2 b; memcpy(b, _b, sizeof(b));

--- a/linmath_test.c
+++ b/linmath_test.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+#include "linmath_test.h"
+
+int main() {
+    linmath_test_run_all();
+    printf("linmath tests passed\n");
+    return 0;
+}

--- a/linmath_test.h
+++ b/linmath_test.h
@@ -1,0 +1,242 @@
+/*
+ * linmath_test.h
+ *
+ *  Created on: Apr 9, 2017
+ *      Author: Danylo Ulianych
+ */
+
+#ifndef LINMATH_TEST_H
+#define LINMATH_TEST_H
+
+#include <stdlib.h>
+#include "linmath.h"
+
+#define LINMATH_EPS                   (0.0001f)
+#define linmath_is_close(val1, val2)  (fabsf(val1 - val2) < LINMATH_EPS)
+
+#ifndef linmath_assert
+#include <assert.h>
+#define linmath_assert                assert
+#endif /* linmath_assert */
+
+
+static float linmath_random_float() {
+	return rand() / (float) RAND_MAX;
+}
+
+#define LINMATH_TEST_DEFINE_VEC(n) \
+static void linmath_vec##n##_set(vec##n v, float value) { \
+	int i; \
+	for (i=0; i<n; i++) { \
+		v[i] = value; \
+	} \
+} \
+static void linmath_vec##n##_init_random(vec##n v) { \
+	int i; \
+	for (i=0; i<n; i++) { \
+		v[i] = linmath_random_float(); \
+	} \
+} \
+static int linmath_vec##n##_allclose(vec##n const a, vec##n const b) { \
+	int i, equal = 1; \
+	for(i = 0; i < n; ++i) \
+		equal &= linmath_is_close(a[i], b[i]); \
+	return equal; \
+} \
+static void linmath_test_vec##n##_mul_inner() { \
+	/* The inner product of a vector of ones with itself must equal 'n'. */ \
+	vec##n v; \
+	linmath_vec##n##_set(v, 1.0f); \
+	float inner_prod = vec##n##_mul_inner(v, v); \
+	linmath_assert(linmath_is_close(inner_prod, n)); \
+} \
+static void linmath_test_vec##n##_len() { \
+	/* The length of a vector of ones must equal sqrt(n). */ \
+	vec##n v; \
+	int i; \
+	for (i=0; i<n; i++) { \
+		v[i] = 1.0f; \
+	} \
+	float norm = vec##n##_len(v); \
+	linmath_assert(linmath_is_close(norm, sqrtf(n))); \
+} \
+static void linmath_test_vec##n##_norm() { \
+	/* The norm of a normalized vector must be 1.0. */ \
+	srand(17U);  /* set any seed */ \
+	vec##n v; \
+	linmath_vec##n##_init_random(v); \
+	vec##n r; \
+	vec##n##_norm(r, v); \
+	float norm = vec##n##_len(r); \
+	linmath_assert(linmath_is_close(norm, 1.0f)); \
+}
+
+
+LINMATH_TEST_DEFINE_VEC(2);
+LINMATH_TEST_DEFINE_VEC(3);
+LINMATH_TEST_DEFINE_VEC(4);
+
+
+static void linmath_test_vec3_mul_cross() {
+	srand(13U);  /* set any seed */
+	vec3 v1, v2, r;
+	linmath_vec3_init_random(v1);
+	vec3_dup(v2, v1);
+	vec3_mul_cross(r, v1, v2);
+	vec3 v_expected;
+
+	// the cross product of equal vectors must be zero
+	linmath_vec3_set(v_expected, 0.0f);
+	linmath_assert(linmath_vec3_allclose(r, v_expected));
+
+	// test ijk axes cross product
+	vec3 i = {1, 0, 0};
+	vec3 j = {0, 1, 0};
+	vec3 k = {0, 0, 1};
+	vec3_mul_cross(r, i, j);
+	linmath_assert(linmath_vec3_allclose(r, k));
+}
+
+static void linmath_test_vec4_mul_cross() {
+	srand(13U);  /* set any seed */
+	vec4 v1, v2, r;
+	linmath_vec4_init_random(v1);
+	vec4_dup(v2, v1);
+	vec4_mul_cross(r, v1, v2);
+	vec4 v_expected;
+
+	// the cross product of equal vectors must be zero
+	linmath_vec4_set(v_expected, 0.0f);
+	v_expected[3] = 1.0f;
+	linmath_assert(linmath_vec4_allclose(r, v_expected));
+
+	// test ijk axes cross product
+	vec4 i = {1, 0, 0, 1};
+	vec4 j = {0, 1, 0, 1};
+	vec4 k = {0, 0, 1, 1};
+	vec4_mul_cross(r, i, j);
+	linmath_assert(linmath_vec4_allclose(r, k));
+}
+
+
+static int linmath_mat4x4_allclose(mat4x4 const M, mat4x4 const N) {
+	int i, equal = 1;
+	for (i = 0; i < 4; ++i)
+		equal &= linmath_vec4_allclose(M[i], N[i]);
+	return equal;
+}
+
+/**
+ * Test the correctnes of a quaternion creation
+ * that is used as a linear operator to rotate
+ * vectors and matrices (later on).
+ */
+static void linmath_test_quat_rotate() {
+    vec3 axis = {0, 1, 0};
+	quat q;
+	float theta = M_PI_4;
+	quat_rotate(q, theta, axis);
+	quat q_refernce = {0, sinf(theta / 2), 0, cosf(theta / 2)};
+	linmath_assert(linmath_vec4_allclose(q, q_refernce));
+}
+
+/**
+ * The conjugate of a quaternion must correspond to
+ * the rotation with a negative angle.
+ */
+static void linmath_test_quat_conj() {
+    srand(15U);
+	quat q, q_conj, q_reference;
+	vec3 axis = { 0, 1, 0 };
+	float angle_rads = linmath_random_float();
+	quat_rotate(q, angle_rads, axis);
+	quat_conj(q_conj, q);
+	quat_rotate(q_reference, -angle_rads, axis);
+	linmath_assert(linmath_vec4_allclose(q_conj, q_reference));
+}
+
+/* Rotate a vector back and forth. */
+static void linmath_test_quat_mul_vec3() {
+	srand(11U);
+	quat q, q_conj;
+	vec3 axis = { 0, 1, 0 };
+	float angle_rads = linmath_random_float();
+	quat_rotate(q, angle_rads, axis);
+	quat_conj(q_conj, q);
+
+	vec3 v_initial, v_rotated, v_restored;
+	linmath_vec3_init_random(v_initial);
+	quat_mul_vec3(v_rotated, q, v_initial);
+	quat_mul_vec3(v_restored, q_conj, v_rotated);
+	linmath_assert(linmath_vec3_allclose(v_restored, v_initial));
+}
+
+/* Rotate a matrix back and forth. */
+static void linmath_test_mat4x4o_mul_quat() {
+	srand(12U);
+	quat q, q_conj;
+	vec3 axis = { 0, 1, 0 };
+	float angle_rads = linmath_random_float();
+	quat_rotate(q, angle_rads, axis);
+	quat_conj(q_conj, q);
+
+	mat4x4 m_reference, m_rotated, m;
+	mat4x4_identity(m_reference);
+	m_reference[0][3] = 0.1f;
+	m_reference[1][3] = 0.2f;
+	m_reference[2][3] = 0.3f;
+	mat4x4o_mul_quat(m_rotated, m_reference, q);
+	mat4x4o_mul_quat(m, m_rotated, q_conj);
+	linmath_assert(linmath_mat4x4_allclose(m_reference, m));
+}
+
+/**
+ * Test if an extracted quaternion from from a
+ * rotational matrix matches the original one.
+ */
+static void linmath_test_quat_from_mat4x4() {
+	srand(7U);
+	quat q_reference;
+	vec3 axis = { 0, 1, 0 };
+	float angle_rads = linmath_random_float();
+	quat_rotate(q_reference, angle_rads, axis);
+
+	mat4x4 m_identity, m_rotated;
+	mat4x4_identity(m_identity);
+	mat4x4o_mul_quat(m_rotated, m_identity, q_reference);
+
+	quat q_restored;
+	quat_from_mat4x4(q_restored, m_rotated);
+	linmath_assert(linmath_vec4_allclose(q_restored, q_reference));
+}
+
+
+
+static void linmath_test_run_all() {
+
+	linmath_test_vec2_mul_inner();
+	linmath_test_vec3_mul_inner();
+	linmath_test_vec4_mul_inner();
+
+	linmath_test_vec2_len();
+	linmath_test_vec3_len();
+	linmath_test_vec4_len();
+
+	linmath_test_vec2_norm();
+	linmath_test_vec3_norm();
+	linmath_test_vec4_norm();
+
+	linmath_test_vec3_mul_cross();
+	linmath_test_vec4_mul_cross();
+
+	linmath_test_quat_rotate();
+	linmath_test_quat_conj();
+	linmath_test_quat_mul_vec3();
+	linmath_test_mat4x4o_mul_quat();
+
+	/* FIXME: Below is the wrecked functional that does not work */
+    // linmath_test_quat_from_mat4x4();
+}
+
+
+#endif /* LINMATH_TEST_H */


### PR DESCRIPTION
* added first tests (partially addresses #4). I skipped some primitive functions, though, in best practice, every function should be tested - I hope others will contribute!
* added CircleCI suite for your repository that will be automatically run on each commit. All you need to do is
  - create an account on circleci.com, if you don't have it yet;
  - choose this project from a list of your projects
  - choose "Use existing config"

  In order to show the badge, I renamed README to README.md
* fixed a bug in `mat4x4o_mul_quat`: the last element in each row of the resulting matrix was not set. Previously, there was junk data.
* Reused `vec4` code for `quat`:
  ```c
  #define quat_add vec4_add
  #define quat_sub vec4_sub
  #define quat_norm vec4_norm
  #define quat_scale vec4_scale
  #define quat_mul_inner vec4_mul_inner
  ```
  Previously, only `#define quat_norm vec4_norm` was set.
* Normalize `axis` to a unit norm in `quat_rotate`. An alternative implementation, when the user has to deal with normalization manually, is
  ```c
  LINMATH_H_FUNC void quat_rotate(quat r, float angle, vec3 const axis) {
    float s = sinf(angle / 2);
    float c = cosf(angle / 2);
    vec3_scale(r, axis, s);
    r[3] = c;
  }
  ```
  The previous version was strange and not optimized. Let me know which one you prefer - force users to manually normalize `axis` (the snippet above, optimized) or take care of the normalization in the function body (current).
* added `vec##n##_dup` function (used it in `mat4x4_dup` and `mat4x4_scale_aniso` functions, and several times in linmath_test.h). Previously, there was only a `mat4x4_dup` function. Also, now we can get rid of unsafe memcpy, which is the only function that requires `<string.h>` to be imported. Let me know if it's better to reuse `vec##n##_dup` instead of `memcpy` (the fix if very easy to add).
* (minor) added const qualifiers to each function (hints). Previously, there were several functions with a const qualifier and most of them didn't have any. We should either put const every time when the argument is not modified or don't use const at all. On second thought, I'm not sure how much it makes sense - for me, the tradeoff of const versus not const has never been clear.

-----

There is a bunch of things. Let me know if you want to include only a part of them.

Danylo

-----

Update 1
I noticed that linmath.h sometimes is used as a submodule to build a C/C++ project. Adding linmath_test.c with a main() function will break such workflows. Does it make sense generating linmath_test.c on the fly at CircleCI runs?

Update 2
I noticed that `quat_inner_product` was used to compute the inner product of two quaternions. Now I redefined it as `#define quat_mul_inner vec4_mul_inner`. Doing so introduces a breaking change for other projects that use linmath. Let me know if I should rename it to `#define quat_inner_product vec4_mul_inner`.