### PR TITLE
Fix quaternion multiplication in place

### DIFF
--- a/linmath.h
+++ b/linmath.h
@@ -453,12 +453,15 @@ LINMATH_H_FUNC void quat_identity(quat q)
 }
 LINMATH_H_FUNC void quat_mul(quat r, quat const p, quat const q)
 {
-	vec3 w;
-	vec3_mul_cross(r, p, q);
+	vec3 w, tmp;
+
+	vec3_mul_cross(tmp, p, q);
 	vec3_scale(w, p, q[3]);
-	vec3_add(r, r, w);
+	vec3_add(tmp, tmp, w);
 	vec3_scale(w, q, p[3]);
-	vec3_add(r, r, w);
+	vec3_add(tmp, tmp, w);
+
+	vec3_dup(r, tmp);
 	r[3] = p[3]*q[3] - vec3_mul_inner(p, q);
 }
 LINMATH_H_FUNC void quat_conj(quat r, quat const q)


### PR DESCRIPTION
Consider a `quat_mul` usage like this:

`quat_mul(o->rotation, o->rotation, q)`

This does not work; the function modifies it's first argument during calculations, and since it's a pointer it messes up the second argument as well
So fix it by introducing a temporary variable